### PR TITLE
Adding Docker images for both arm64 and amd64 platforms

### DIFF
--- a/dotnet/dockerfiles/drivers
+++ b/dotnet/dockerfiles/drivers
@@ -1,3 +1,3 @@
-FROM microsoft/azure-functions-dotnet-core2.0:v2.0.11961-alpha
+FROM mohsinonxrm/azure-functions-dotnet:4
 
-COPY ./ServerlessMicroservices.FunctionApp.Drivers/bin/Debug/netstandard2.0 /home/site/wwwroot
+COPY ./ServerlessMicroservices.FunctionApp.Drivers /home/site/wwwroot

--- a/dotnet/dockerfiles/orchestrators
+++ b/dotnet/dockerfiles/orchestrators
@@ -1,3 +1,3 @@
-FROM microsoft/azure-functions-dotnet-core2.0:v2.0.11961-alpha
+FROM mohsinonxrm/azure-functions-dotnet:4
 
-COPY ./ServerlessMicroservices.FunctionApp.Orchestrators/bin/Debug/netstandard2.0 /home/site/wwwroot
+COPY ./ServerlessMicroservices.FunctionApp.Orchestrators /home/site/wwwroot

--- a/dotnet/dockerfiles/passengers
+++ b/dotnet/dockerfiles/passengers
@@ -1,3 +1,3 @@
-FROM microsoft/azure-functions-dotnet-core2.0:v2.0.11961-alpha
+FROM mohsinonxrm/azure-functions-dotnet:4
 
-COPY ./ServerlessMicroservices.FunctionApp.Passengers/bin/Debug/netstandard2.0 /home/site/wwwroot
+COPY ./ServerlessMicroservices.FunctionApp.Passengers /home/site/wwwroot

--- a/dotnet/dockerfiles/trips
+++ b/dotnet/dockerfiles/trips
@@ -1,3 +1,3 @@
-FROM microsoft/azure-functions-dotnet-core2.0:v2.0.11961-alpha
+FROM mohsinonxrm/azure-functions-dotnet:4
 
-COPY ./ServerlessMicroservices.FunctionApp.Trips/bin/Debug/netstandard2.0 /home/site/wwwroot
+COPY ./ServerlessMicroservices.FunctionApp.Trips /home/site/wwwroot


### PR DESCRIPTION
Hi

**Package Owner**: Anil Reddy
**PR change Details**:
**Patch Details**: Following file has been modified:
Modified files dotnet/dockerfiles/drivers, dotnet/dockerfiles/orchestrators, dotnet/dockerfiles/passengers, dotnet/dockerfiles/trips for adding Docker images for both arm64 and amd64 platforms.
**PR Description**: Here is my commit message:
Adding Docker images for both arm64 and amd64 platforms
**PR Description**:
The following file has been modified:
Modified files dotnet/dockerfiles/drivers, dotnet/dockerfiles/orchestrators, dotnet/dockerfiles/passengers, dotnet/dockerfiles/trips for adding Docker images for both arm64 and amd64 platforms.

**Reviewer**: Disha Srivastava, Akhand pratap
Thanks
Anil Reddy
**Signed-off-by**: odidev@puresoftware.com